### PR TITLE
Fix PHP Notice for curl (>= 7.28.1)

### DIFF
--- a/vendors/rest_client/Curl.php
+++ b/vendors/rest_client/Curl.php
@@ -251,9 +251,9 @@ class Curl {
             curl_setopt($this->request, CURLOPT_COOKIEJAR, $this->cookie_file);
         }
 
-        curl_setopt($this->request, CURLOPT_SSL_VERIFYHOST, !!$this->verify_ssl);
+        curl_setopt($this->request, CURLOPT_SSL_VERIFYHOST, (!!$this->verify_ssl ? 2 : 0));
         curl_setopt($this->request, CURLOPT_SSL_VERIFYPEER, !!$this->verify_ssl);
-        
+
         if ($this->follow_redirects) curl_setopt($this->request, CURLOPT_FOLLOWLOCATION, true);
         if ($this->referer) curl_setopt($this->request, CURLOPT_REFERER, $this->referer);
 


### PR DESCRIPTION
Support for '1' as a valid value for parameter CURLOPT_SSL_VERIFYHOST has been dropped. Use '2' instead, or '0' if you joined the dark side.

Link: http://php.net/manual/en/function.curl-setopt.php
